### PR TITLE
AODA Fixes Package #3 - Scoban

### DIFF
--- a/pjtk2/templates/pjtk2/ProjectSearch.html
+++ b/pjtk2/templates/pjtk2/ProjectSearch.html
@@ -78,11 +78,11 @@
 
                             <div class="form-group">
                                 <input type="text" class="form-control" id="first-year" name="first_year" placeholder =
-                                            "first year">
+                                            "first year (YYYY)" aria-label="first year (YYYY)">
                             </div>
                             <div class="form-group mt-3">
                                 <input type="text" class="form-control" id="last-year" name="last_year" placeholder =
-                                            "last year">
+                                            "last year (YYYY)" aria-label="last year (YYYY)">
                             </div>
                             <div class="form-group mt-3">
                                 <button class="btn btn-outline-secondary btn-sm text-dark" type="button" onClick=handleClick()>
@@ -109,7 +109,7 @@
 
                             <div class="form-group">
                                 <input type="text" class="form-control"  name="prj_cd__like" placeholder =
-                                             "Project Code Contains..." value="{{filters.prj_cd__like}}">
+                                             "Project Code Contains..." aria-label="Project Code" value="{{filters.prj_cd__like}}">
                             </div>
 
                             {% include "pjtk2/_search_hidden_inputs.html" %}

--- a/pjtk2/templates/pjtk2/UploadSpatialPoints.html
+++ b/pjtk2/templates/pjtk2/UploadSpatialPoints.html
@@ -12,7 +12,7 @@
 
 
         <a class="btn btn-info btn-sm" style="margin-bottom:5px"role="button" data-bs-toggle="collapse" href="#additional-information" aria-expanded="false" aria-controls="additional-information">
-            Additional Details....
+            Click for Additional Details....
         </a>
 
         <div class="collapse" id="additional-information">

--- a/pjtk2/templates/pjtk2/pjtk2_base.html
+++ b/pjtk2/templates/pjtk2/pjtk2_base.html
@@ -21,6 +21,10 @@
              filter: none;
              background-image: none;
          }
+         button:disabled {
+            cursor: not-allowed;
+            pointer-events: all !important;
+         }
         </style>
 
 

--- a/pjtk2/templates/pjtk2/projectdetail.html
+++ b/pjtk2/templates/pjtk2/projectdetail.html
@@ -331,12 +331,14 @@
                     <legend> Milestones:</legend>
                     <hr>
                     {% for milestone in milestones %}
-                        <input type="checkbox" disabled="disabled"
-                               {% if milestone.completed  %}
-                               checked="checked"
-                               {% endif %}
-                        />
+                    <span class="text-nowrap">
+                        {% if milestone.completed  %}
+                            <i class="fa fa-check-square-o ms-3" aria-label="Required"></i>
+                        {% else %}
+                            <i class="fa fa-square-o ms-3" aria-label="Not Required"></i>
+                        {% endif %}
                         {{ milestone.milestone.label }}
+                    </span>
                     {% endfor %}
 
                 </fieldset>
@@ -402,17 +404,17 @@
 
             <a href="#" onclick="javascript:window.location=this.href">
                 <a href="{% url 'uncancel_project' project.slug %}" onclick="javascript:window.location=this.href">
-                    <button type="button" class="btn btn-danger">Un-Cancel</button> </a>
+                    <button type="button" class="btn btn-danger mx-1">Un-Cancel</button> </a>
 
                 {% else %}
 
                 <a href="{% url 'Reports' project.slug %}?next={{ request.path|urlencode }}"
                    onclick="javascript:window.location=this.href">
-                    <button type="button" class="btn btn-primary">Change Reporting Requirements</button> </a>
+                    <button type="button" class="btn btn-primary mx-1">Change Reporting Requirements</button> </a>
 
 
                 <a href="{% url 'cancel_project' project.slug %}" onclick="javascript:window.location=this.href">
-                    <button type="button" class="btn btn-danger">Cancel</button> </a>
+                    <button type="button" class="btn btn-danger mx-1">Cancel</button> </a>
                 {% endif %}
 
                 {% else %}
@@ -448,17 +450,20 @@
             {% for report in Core  %}
 
             <tr>
-                <td > <input type="checkbox" disabled="disabled"
-                             {% if report.required %} checked="checked" {% endif %}>
-                    {{ report.milestone }}{% if report.milestone.shared and has_sister %}*{% endif %}
+                <td >{% if report.required %}
+                        <i class="fa fa-check-square-o" aria-label="Required"></i>
+                    {% else %}
+                        <i class="fa fa-square-o" aria-label="Not Required"></i>
+                    {% endif %}
+                    
                 </td>
-
+                <td>{{ report.milestone }}{% if report.milestone.shared and has_sister %}*{% endif %}</td>
                 {% if report.report %}
                     <td><a href="{% url 'serve_file' filename=report.report %}">{{ report.report }}</a></td>
 
                 {% if edit %}
                 <td>
-                    <a href="{% url 'delete_report' slug=project.slug pk=report.report.id %}" class="btn btn-danger btn-sm" title="Delete Report" role="button">
+                    <a href="{% url 'delete_report' slug=project.slug pk=report.report.id %}" class="btn btn-danger btn-sm" aria-label="Delete Report" title="Delete Report" role="button">
                         <span class="fa fa-times"></span>
                     </a>
                 </td>
@@ -513,10 +518,8 @@
                     <td><a href="{% url 'serve_file' report.report %}">{{ report.report }}</a></td>
                     {% if edit %}
                 <td>
-                    <a href="{% url 'delete_report' slug=project.slug pk=report.report.id %}">
-                        <button type="button" class="btn btn-danger btn-sm">
-                            <span class="fa fa-times"></span>
-                        </button>
+                    <a href="{% url 'delete_report' slug=project.slug pk=report.report.id %}" button type="button" class="btn btn-danger btn-sm" title="Delete Report" aria-label="Delete Report">
+                        <span class="fa fa-times"></span>
                     </a>
                 </td>
                 {% else %}
@@ -576,10 +579,8 @@
                 {% endif %}
                 {% if edit %}
                 <td>
-                    <a href="{% url 'delete_associated_file' file.id %}">
-                        <button type="button" class="btn btn-danger btn-sm">
-                            <span class="fa fa-times"></span>
-                        </button>
+                    <a href="{% url 'delete_associated_file' file.id %}" button type="button" class="btn btn-danger btn-sm" title="Delete File" aria-label="Delete File">
+                        <span class="fa fa-times"></span>
                     </a>
                 </td>
                 {% endif %}

--- a/pjtk2/templates/pjtk2/reportform.html
+++ b/pjtk2/templates/pjtk2/reportform.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<div class="container" >
+<div class="container p-4" >
 
     <h2> Update Reporting Requirements</h2>
     <hr />
@@ -18,9 +18,9 @@
 
         <div class="row" >
             <div class="col-md-4" >
-                <div class="panel panel-default">
-                    <div class="panel-heading">Project Milestones:</div>
-                    <div class="panel-body">
+                <div class="card card-default mb-2">
+                    <div class="card-header">Project Milestones:</div>
+                    <div class="card-body">
                         <div class="col-md-offset-1 ">
                             {{  Milestones|crispy }}
                         </div>
@@ -30,9 +30,9 @@
 
             <div class="row" >
                 <div class="col-md-4" >
-                    <div class="panel panel-default">
-                        <div class="panel-heading">Core Reporting Requirements:</div>
-                        <div class="panel-body">
+                    <div class="card card-default mb-2">
+                        <div class="card-header">Core Reporting Requirements:</div>
+                        <div class="card-body">
                             <div class="col-md-offset-1 ">
                                 {{ Core|crispy }}
                             </div>
@@ -42,9 +42,9 @@
 
                 <div class="row" >
                     <div class="col-md-4" >
-                        <div class="panel panel-default">
-                            <div class="panel-heading">Additional Reporting Requirements:</div>
-                            <div class="panel-body">
+                        <div class="card card-default">
+                            <div class="card-header">Additional Reporting Requirements:</div>
+                            <div class="card-body">
                                 <div class="col-md-offset-1 ">
                                     {{ Custom|crispy }}
                                 </div>
@@ -63,10 +63,10 @@
                 <button class="btn btn-primary" type="submit">Save Changes</button>
 
 
-                <button class="btn btn-default" data-toggle="modal" data-target="#modalMilestone">
+                <button type="button" class="btn btn-outline-secondary text-dark" data-bs-toggle="modal" data-bs-target="#modalMilestone">
                     New Milestone
                 </button>
-                <button class="btn btn-default" data-toggle="modal" data-target="#modalReport">
+                <button type="button" class="btn btn-outline-secondary text-dark" data-bs-toggle="modal" data-bs-target="#modalReport">
                     New Report
                 </button>
 
@@ -80,19 +80,19 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button id="milestoneButton" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                     <h4 class="modal-title">New Milestone</h4>
+                    <button id="milestoneButton" type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true" aria-label="Close window"></button>
                 </div>
                 <div class="modal-body">
                     <form class="form-horizontal" role="form" method="POST" id="dialog2" name="dialog2" action="">
                         {% csrf_token  %}
 
-                        <div class="row" >
+                        <div class="row mx-2" >
                             <div class="col-md-10" >
-                                <input type="text" name="new_milestone" class="form-control"/>
+                                <input type="text" name="new_milestone" class="form-control" aria-label="New Milestone"/>
                             </div>
                             <div class="col-md-2" >
-                                <input type="submit"  value="Submit" name="Submit" class="btn btn-default"/>
+                                <input type="submit"  value="Submit" name="Submit" class="btn btn-primary"/>
                             </div>
                         </div>
 
@@ -106,20 +106,20 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button id="reportButton" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                     <h4 class="modal-title">New Report</h4>
+                    <button id="reportButton" type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true" aria-label="Close window"></button>
                 </div>
                 <div class="modal-body">
 
                     <form method="POST" id="dialog" action="">
                         {% csrf_token  %}
 
-                        <div class="row" >
+                        <div class="row mx-2" >
                             <div class="col-md-10" >
-                                <input type="text" name="new_report" class="form-control"/>
+                                <input type="text" name="new_report" class="form-control" aria-label="New Report"/>
                             </div>
                             <div class="col-md-2" >
-                                <input type="submit"  value="Submit" name="Submit" class="btn btn-default"/>
+                                <input type="submit"  value="Submit" name="Submit" class="btn btn-primary"/>
                             </div>
                         </div>
 

--- a/pjtk2/tests/integration_tests/test_delete_files.py
+++ b/pjtk2/tests/integration_tests/test_delete_files.py
@@ -200,7 +200,7 @@ class DeleteReportLinkOnDetailPageTestCase(WebTest):
         url = reverse(
             "delete_report", kwargs={"slug": self.project.slug, "pk": self.report.id}
         )
-        url = '<a href="{0}" class="btn btn-danger btn-sm" title="Delete Report" role="button">'.format(url)
+        url = '<a href="{0}" class="btn btn-danger btn-sm" aria-label="Delete Report" title="Delete Report" role="button">'.format(url)
         self.assertContains(response, url)
 
     def test_manager_has_delete_link(self):
@@ -229,7 +229,7 @@ class DeleteReportLinkOnDetailPageTestCase(WebTest):
         url = reverse(
             "delete_report", kwargs={"slug": self.project.slug, "pk": self.report.id}
         )
-        url = '<a href="{0}" class="btn btn-danger btn-sm" title="Delete Report" role="button">'.format(url)
+        url = '<a href="{0}" class="btn btn-danger btn-sm" aria-label="Delete Report" title="Delete Report" role="button">'.format(url)
         self.assertContains(response, url)
 
     def test_admin_has_delete_link(self):
@@ -256,7 +256,7 @@ class DeleteReportLinkOnDetailPageTestCase(WebTest):
         url = reverse(
             "delete_report", kwargs={"slug": self.project.slug, "pk": self.report.id}
         )
-        url = '<a href="{0}" class="btn btn-danger btn-sm" title="Delete Report" role="button">'.format(url)
+        url = '<a href="{0}" class="btn btn-danger btn-sm" aria-label="Delete Report" title="Delete Report" role="button">'.format(url)
         self.assertContains(response, url)
 
     def test_joe_user_does_not_have_delete_link(self):

--- a/pjtk2/tests/integration_tests/test_views.py
+++ b/pjtk2/tests/integration_tests/test_views.py
@@ -745,11 +745,11 @@ class TestDetailPageCancelledProjects(TestCase):
         )
 
         self.CancelBtn = (
-            '<button type="button" ' + 'class="btn btn-danger">Cancel</button>'
+            '<button type="button" ' + 'class="btn btn-danger mx-1">Cancel</button>'
         )
 
         self.UnCancelBtn = (
-            '<button type="button" ' + 'class="btn btn-danger">Un-Cancel</button>'
+            '<button type="button" ' + 'class="btn btn-danger mx-1">Un-Cancel</button>'
         )
 
     def test_no_cancel_btn_unapproved_projects(self):


### PR DESCRIPTION
pjtk_base.html: CSS button:disabled styling added. Hovering over disabled buttons displays cursor as a Ghostbusters symbol.

projectdetail.html: Checkbox form controls replaced by FontAwesome checkbox icons (applies to Milestones and Core Reporting Requirements). Aria-labels added to icons based on checkbox state. Checked = “Required”, unchecked = “Not required”.

projectdetail.html: <button> element removed, and hyperlink is instead made to act like a button using role=‘button’ and adding ‘btn’ to the class so that it appears as a button. Title and aria-label is also added to the hyperlink, so it is now accessible.

Projectdetail.html: mx padding added to Change Reporting Requirements, Cancel, and Un-Cancel buttons.

Projectdetail.html: ms-3 padding added to milestone items, <span> tags added to milestone items to keep checkbox icons and labels together as one element.

ProjectSearch.html: aria-labels added to form fields: first year, last year, and project code.

reportform.html: Bootstrap 5 update applied to page; panels to cards, added padding, and button styles updated.

reportform.html: modal dialogue boxes updated; added padding, close and submit button styles updated, aria-label added to textbox form field.

UploadSpatialPoints.html: additional text added to Additional Details.... button just for extra clarity for the user

test_delete_files.py and test_views.py: test cases updated to match current local version; now looks for the updated elements.